### PR TITLE
Remove foreign key constraint from `tax_rate_id`

### DIFF
--- a/database/migrations/2025_03_12_061830_create_purchase_orders_table.php
+++ b/database/migrations/2025_03_12_061830_create_purchase_orders_table.php
@@ -19,8 +19,6 @@ return new class extends Migration
             $table->date('expected_delivery_date');
             $table->enum('status', ['pending', 'partially_received', 'received'])->default('pending');
             $table->timestamps();
-
-            $table->foreign('tax_rate_id')->references('id')->on('tax_rates');
         });
     }
 


### PR DESCRIPTION
This pull request removes the foreign key constraint on the `tax_rate_id` column in the `purchase_orders` migration. This adjustment provides greater flexibility by allowing the `tax_rate_id` field to operate independently of the `tax_rates` table.